### PR TITLE
Fix RunKind for predefined symbols

### DIFF
--- a/src/Language Modules/Go.plist
+++ b/src/Language Modules/Go.plist
@@ -69,7 +69,7 @@
 		
 		<dict>
 			<key>RunKind</key>
-			<string>com.barebones.bblm.predefined-symbols</string>
+			<string>com.barebones.bblm.predefined-symbol</string>
 			<key>Keywords</key>
 			<array>
 				<string>append</string>


### PR DESCRIPTION
Predefined symbols weren't getting highlighted because the RunKind was wrong. Verified in BBEdit 11.5.
